### PR TITLE
BY-1: check if a hash is a discovery

### DIFF
--- a/packages/lib/src/utils/discovery.test.ts
+++ b/packages/lib/src/utils/discovery.test.ts
@@ -1,0 +1,18 @@
+import { isDiscovery } from './discovery';
+
+describe('isDiscovery', () => {
+  it('should return whether the input starts with a 0[0-7]', () => {
+    // not long enough
+    expect(isDiscovery('')).toEqual(false);
+    expect(isDiscovery('0')).toEqual(false);
+
+    // first character not 0
+    expect(isDiscovery('10')).toEqual(false);
+
+    // all valid
+    expect(isDiscovery('00')).toEqual(true);
+    expect(isDiscovery('07')).toEqual(true);
+    expect(isDiscovery('04')).toEqual(true);
+    expect(isDiscovery('00ffffff')).toEqual(true);
+  });
+});

--- a/packages/lib/src/utils/discovery.ts
+++ b/packages/lib/src/utils/discovery.ts
@@ -1,0 +1,3 @@
+export const isDiscovery = (s: string) => {
+  return s.match(/^0[0-7]/) !== null;
+};


### PR DESCRIPTION
### Issue reference

<!--

Reference the issue or issues that this pull request is meant to solve. Use closing tags to have GitHub automatically close the issues when the pull request is merged.

Good examples are:
- Closes
- Fixes
- Resolves

https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

Please don't open pull requests without first opening or reading over an issue relating to the change. If you're really set on opening one without an issue, you may simply write N/A, or remove this section.

-->

Closes #1 

### Description of the change

<!--

In a short paragraph describe what you've done to solve or implement the changes required for the selected issue. If there is no issue reference, you'll have to do the work of an issue and explain in detail why this code change was put together.

-->

Adds a util method to check if a hash counts as a discovery (aka "big yikes"). In practice, the has will be computed from a structure.
